### PR TITLE
Fix yml: use strings for environment vars

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -3,14 +3,14 @@ web:
   volumes:
     - ./data/media:/media
   environment:
-    DATABASE_ENGINE: django.db.backends.mysql
-    DATABASE_HOST: mysql
-    DATABASE_NAME: puput
-    DATABASE_USER: upuput
-    DATABASE_PASSWORD: changeme
+    DATABASE_ENGINE: "django.db.backends.mysql"
+    DATABASE_HOST: "mysql"
+    DATABASE_NAME: "puput"
+    DATABASE_USER: "upuput"
+    DATABASE_PASSWORD: "changeme"
     ALLOWED_HOSTS: "*"
-    DEBUG: False
-    SECRET_KEY: alsochangeme_
+    DEBUG: "False"
+    SECRET_KEY: "alsochangeme_"
 
 mysql:
   image: mysql:5.6
@@ -18,10 +18,10 @@ mysql:
     - ./data/mysql:/var/lib/mysql
     - ./conf/mysql:/etc/mysql/conf.d
   environment:
-    MYSQL_ROOT_PASSWORD: changeme
-    MYSQL_DATABASE: puput
-    MYSQL_USER: upuput
-    MYSQL_PASSWORD: changeme
+    MYSQL_ROOT_PASSWORD: "changeme"
+    MYSQL_DATABASE: "puput"
+    MYSQL_USER: "upuput"
+    MYSQL_PASSWORD: "changeme"
 
 redis:
   image: redis:3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ web:
     - redis:redis-master
     - mysql
   environment:
-    DEBUG: True
+    DEBUG: "True"
 
 mysql:
   extends:


### PR DESCRIPTION
Fixes:

> ERROR: The Compose file './docker-compose.yml' is invalid because:
> web.environment.DEBUG contains true, which is an invalid type, it should be a string, number, or a null